### PR TITLE
fix: Fix schema-07.json schema to work on jetbrains IDEs properly

### DIFF
--- a/schema-07.json
+++ b/schema-07.json
@@ -9,14 +9,14 @@
       "description": "The list of fursonas for this person.",
       "type": "array",
       "items": {
-        "$ref": "sona"
+        "$ref": "#/definitions/sona"
       }
     }
   },
   "required": [
     "sonas"
   ],
-  "$defs": {
+  "definitions": {
     "sona": {
       "$id": "sona",
       "description": "A single fursona",


### PR DESCRIPTION
I used Webstorm to validate it working, by temporarily adding a second array entry to example.json and letting me show all available arguments with ctrl+space.

This will close #8 